### PR TITLE
Fix order grab images

### DIFF
--- a/gifmaker/gifmaker.py
+++ b/gifmaker/gifmaker.py
@@ -97,8 +97,10 @@ def main():
     # then, check if "*" needs to be interpreted
     if any("*" in s for s in infiles) and len(infiles) == 1:
         infiles = glob.glob(infiles[0])
-
+    
+    infiles.sort()
     print("Input files:\n{}".format(infiles))
+
     creategif(infiles, outfile, duration, rescale_factor, interp, crop, args.save_indiv)
 
 


### PR DESCRIPTION
Fixes #2 

Output example:

```
(base) alfoi@MacBook-Pro:images % ls
1.png 2.png 3.png 4.png 5.png
(base) alfoi@MacBook-Pro:images % gifmaker 
Input files:
['1.png', '2.png', '3.png', '4.png', '5.png']
File created: anim.gif
```
![anim](https://user-images.githubusercontent.com/12564433/92156989-c79ece80-edf7-11ea-8b35-cdce19233873.gif)


To test:
```
git checkout af/2-fix-order
pip install -e .
```
